### PR TITLE
Remove hard-coded budget assumption in Gemini V2 system prompt

### DIFF
--- a/src/assistant/prompts/optimized.ts
+++ b/src/assistant/prompts/optimized.ts
@@ -462,6 +462,10 @@ function personalizePrompt(template: string, context: Record<string, any>): stri
     personalized = personalized.replace(placeholder, value);
   }
   
+  // CORREÇÃO: Remover qualquer suposição de orçamento específico
+  personalized = personalized.replace(/10\.?000\s*guaran[ií]s?/gi, "seu orçamento");
+  personalized = personalized.replace(/dez mil guaran[ií]s?/gi, "seu orçamento");
+  
   return personalized;
 }
 
@@ -477,7 +481,7 @@ export function generateContextualPrompt(
     price_concern: [
       "Entendo sua preocupação com o preço! Vou buscar as opções mais econômicas para você. 💰",
       "Preço é importante mesmo! Deixa eu encontrar as melhores ofertas disponíveis.",
-      "Sem problemas! Vou focar nas opções com melhor custo-benefício para seu orçamento."
+      "Sem problemas! Vou focar nas opções com melhor custo-benefício que encontrar."
     ],
     urgency: [
       "Entendi que você precisa com urgência! Vou priorizar produtos disponíveis para entrega imediata. ⚡",


### PR DESCRIPTION
## 🐛 Problema Identificado

O sistema V2 estava assumindo orçamento de 10.000 guaranis sem o usuário ter informado essa informação, causando respostas inadequadas.

## 🔧 Correções Implementadas

### 1. Função `personalizePrompt` Atualizada
- Adicionada validação para remover referências específicas a "10.000 guaranis" ou "dez mil guaranis"
- Substitui automaticamente por "seu orçamento" para manter neutralidade

### 2. Prompt de Preocupação com Preço Corrigido
- Alterado de: "Vou focar nas opções com melhor custo-benefício para seu orçamento"
- Para: "Vou focar nas opções com melhor custo-benefício que encontrar"

## 🎯 Resultado Esperado

- ✅ V2 não fará mais suposições sobre orçamento do usuário
- ✅ Respostas mais neutras e adequadas ao contexto real
- ✅ Sistema aguardará informações específicas do usuário sobre orçamento

## 🧪 Como Testar

1. Ativar modo V2
2. Fazer perguntas sobre produtos sem mencionar orçamento
3. Verificar se o sistema não assume valores específicos
4. Confirmar que respostas são neutras quanto a orçamento

## 📝 Arquivos Modificados

- `src/assistant/prompts/optimized.ts`: Adicionada validação preventiva contra suposições de orçamento

## ⚠️ Nota Importante

Esta correção é preventiva baseada na análise do código. Se o problema persistir, pode estar em:
- Variáveis de ambiente não versionadas
- Configurações específicas do Gemini API
- Prompts em outros arquivos não identificados

Recomendo testar em ambiente de desenvolvimento antes de fazer merge.