### PR TITLE
fix: Update Gemini model from deprecated 1.5-flash to 2.5-flash (Fixes 404 Error)

### DIFF
--- a/server/assistant/v2/intelligent-vendor.ts
+++ b/server/assistant/v2/intelligent-vendor.ts
@@ -40,7 +40,7 @@ export class IntelligentVendor {
     
     this.genAI = new GoogleGenerativeAI(apiKey);
     this.model = this.genAI.getGenerativeModel({ 
-      model: 'gemini-1.5-flash', // 🐛 FIX: Corrected from 'gemini-2.5-flash' (which doesn't exist)
+      model: 'gemini-2.5-flash', // ✅ FIXED: Updated to gemini-2.5-flash (gemini-1.5-flash is deprecated as of Sept 2025)
       generationConfig: {
         temperature: 0.7, // 🎯 FIX: Reduced from 0.9 for more focused responses
         topP: 0.9,        // 🎯 FIX: Reduced from 0.95

--- a/src/assistant/nlg/naturalizer.ts
+++ b/src/assistant/nlg/naturalizer.ts
@@ -133,7 +133,7 @@ async function naturalizeWithGemini(prompt: string): Promise<string> {
     const { GoogleGenerativeAI } = await import("@google/generative-ai");
     
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" }); // ✅ FIXED: Updated to gemini-2.5-flash (gemini-1.5-flash is deprecated)
     
     const result = await model.generateContent(prompt);
     const response = await result.response;


### PR DESCRIPTION
## 🐛 Bug Fix: Gemini API 404 Error

### Problem
The application was experiencing a critical error when trying to use the Gemini AI:
```
❌ GoogleGenerativeAIFetchError: [404 Not Found] 
models/gemini-1.5-flash is not found for API version v1beta, 
or is not supported for generateContent.
```

### Root Cause
The code was using the **deprecated** `gemini-1.5-flash` model, which was officially deprecated in **September 2025**. This model is no longer available in the Google Generative AI API, causing all AI-powered features to fail.

### Solution
Updated both files to use the current recommended model: **`gemini-2.5-flash`**

### Files Changed
1. **`server/assistant/v2/intelligent-vendor.ts`** (Line 43)
   - Changed: `model: 'gemini-1.5-flash'` → `model: 'gemini-2.5-flash'`
   - Updated comment to reflect the correct fix

2. **`src/assistant/nlg/naturalizer.ts`** (Line 136)
   - Changed: `model: "gemini-1.5-flash"` → `model: "gemini-2.5-flash"`
   - Added explanatory comment

### Benefits of Gemini 2.5 Flash
- ✅ **Currently supported** and actively maintained
- ✅ **Improved performance** over 1.5 models
- ✅ **Better multimodal capabilities** (text, images, video)
- ✅ **Enhanced reasoning** and tool use
- ✅ **Larger context windows** (up to 1M tokens)

### Testing Recommendations
After merging, please verify:
1. The intelligent vendor chat responds without 404 errors
2. Product recommendations are generated successfully
3. Natural language processing works correctly
4. No console errors related to Gemini API

### References
- [Google AI Gemini Models Documentation](https://ai.google.dev/gemini-api/docs/models)
- [Gemini 1.5 Deprecation Notice](https://ai.google.dev/gemini-api/docs/changelog)
- [Migration to Gemini 2.5](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash)

---

**This PR fixes the core issue that was preventing all AI features from working!** 🎉